### PR TITLE
fix(oscillator): fix oscillator observation space

### DIFF
--- a/envs/oscillator.py
+++ b/envs/oscillator.py
@@ -31,10 +31,11 @@ class oscillator(gym.Env):
         self.t = 0
         self.sigma = 0.
         # Angle limit set to 2 * theta_threshold_radians so failing observation is still within bounds
-        high = np.array([1, 1, 1, 1, 1, 1, 1, 1])
+        low = np.array([0., 0., 0., 0., 0., 0., 0., -np.inf])
+        high = np.array([np.inf, np.inf, np.inf, np.inf, np.inf, np.inf, np.inf, np.inf])
 
         self.action_space = spaces.Box(low=np.array([0., 0.,0.]), high=np.array([1, 1, 1]), dtype=np.float32)
-        self.observation_space = spaces.Box(-high, high, dtype=np.float32)
+        self.observation_space = spaces.Box(low, high, dtype=np.float32)
 
         self.seed()
         self.viewer = None
@@ -155,7 +156,3 @@ if __name__=='__main__':
     ax.legend(handles, labels, loc=2, fancybox=False, shadow=False)
     plt.show()
     print('done')
-
-
-
-

--- a/envs/oscillator_complicated.py
+++ b/envs/oscillator_complicated.py
@@ -32,10 +32,11 @@ class oscillator(gym.Env):
         self.t = 0
         self.sigma = 0
         # Angle limit set to 2 * theta_threshold_radians so failing observation is still within bounds
-        high = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+        low = np.array([0., 0., 0., 0., 0., 0., 0., 0., 0., -np.inf])
+        high = np.array([np.inf, np.inf, np.inf, np.inf, np.inf, np.inf, np.inf, np.inf, np.inf, np.inf])
 
         self.action_space = spaces.Box(low=np.array([0., 0., 0., 0.]), high=np.array([1, 1, 1, 1]), dtype=np.float32)
-        self.observation_space = spaces.Box(-high, high, dtype=np.float32)
+        self.observation_space = spaces.Box(low, high, dtype=np.float32)
 
         self.seed()
         self.viewer = None
@@ -166,7 +167,3 @@ if __name__=='__main__':
     ax.legend(handles, labels, loc=2, fancybox=False, shadow=False)
     plt.show()
     print('done')
-
-
-
-


### PR DESCRIPTION
This pull request ensures that the observation space aligns with the one used in [Han et al. 2020](https://arxiv.org/abs/2004.14288). The current observation space ($a \in [-1, 1]$) would not have produced the same plots as those given in the paper. This discrepancy is more of a technicality, as the observation space is not strictly enforced.

![image](https://github.com/hithmh/Actor-critic-with-stability-guarantee/assets/17570430/cf683407-ff76-4fa6-97ee-90f7c7c60dc5)