### PR TITLE
fix(minitaur): align cost with Han et al. 2020

### DIFF
--- a/envs/minitaur_env.py
+++ b/envs/minitaur_env.py
@@ -9,14 +9,14 @@ OBSERVATION_EPS = 0.01
 
 class minitaur_env(e.MinitaurBulletEnv):
     def __init__(self, **kwargs):
-        self._velocity_weight = 0.
+        self._velocity_weight = 1.0
         self.target_velocity = 1.
         self.target_position_range = np.asarray([1, 1])
         self.target_velocity_range = np.asarray(1)
         super(minitaur_env, self).__init__(**kwargs)
 
 
-        self._distance_weight = 1.
+        self._distance_weight = 0.
         self._energy_weight = 0.
         self._drift_weight = 0
         self._shake_weight = 0


### PR DESCRIPTION
This pull request ensures the cost function used in the Minitaur environment aligns with the one described in [Han et al. 2020](https://arxiv.org/abs/2004.14288).
